### PR TITLE
Allow empty VPC configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ module "rotation" {
   role_arn           = module.secret.rotation_role_arn
   runtime            = "python3.8"
   secret_arn         = module.secret.arn
-  security_group_ids = [aws_security_group.function.id]
+  security_group_ids = length(var.subnet_ids) > 0 ? [aws_security_group.function.id] : []
   source_file        = "${path.module}/rotation/lambda_function.py"
   subnet_ids         = var.subnet_ids
   variables          = { USERNAME = aws_iam_user.mail.name }

--- a/variables.tf
+++ b/variables.tf
@@ -41,9 +41,11 @@ variable "trust_tags" {
 variable "subnet_ids" {
   description = "Subnets in which the rotation function should run"
   type        = list(string)
+  default     = []
 }
 
 variable "vpc_id" {
   description = "VPC in which the rotation function should run"
   type        = string
+  default     = null
 }


### PR DESCRIPTION
With thoughtbot/terraform-aws-secrets#1, the AWS secrets module no longer requires VPC config to be supplied, so it seems they shouldn't be required by this one, either -- or at least I am seeing no ill effects from making this change and passing empty VPC config.