### PR TITLE
Add IAM user name to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "smtp_user_name" {
+  description = "IAM user name of the SMTP user"
+  value       = aws_iam_user.mail.name
+}
+
 output "policy_json" {
   description = "Required IAM policies"
   value       = module.secret.policy_json


### PR DESCRIPTION
Add IAM user name to outputs, so that calling modules can, for example, associate additional IAM policies to it.