### PR TITLE
Bump Terraform AWS provider from version 4 to 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ secret. You can add this to an IAM role or policy.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.4.0 |
-| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret | v0.4.0 |
+| <a name="module_rotation"></a> [rotation](#module\_rotation) | github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function | v0.8.0 |
+| <a name="module_secret"></a> [secret](#module\_secret) | github.com/thoughtbot/terraform-aws-secrets//secret | v0.8.0 |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ secret. You can add this to an IAM role or policy.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "send_mail" {
 }
 
 module "secret" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret?ref=v0.8.0"
 
   admin_principals = var.admin_principals
   description      = "SMTP username and password for ${var.name}"
@@ -45,7 +45,7 @@ module "secret" {
 }
 
 module "rotation" {
-  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.4.0"
+  source = "github.com/thoughtbot/terraform-aws-secrets//secret-rotation-function?ref=v0.8.0"
 
   handler            = "lambda_function.lambda_handler"
   role_arn           = module.secret.rotation_role_arn

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0

Ref:
- https://trello.com/c/MIAiwlJ4/25-update-terraform-modules-to-support-aws-v5-providers