### PR TITLE
Update Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,17 @@
+---
 version: 2
+
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "02:00"
+      timezone: "Etc/UTC"
+
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "02:00"
+      timezone: "Etc/UTC"


### PR DESCRIPTION
Currently, we manually update our Terraform providers.

This commit configures Dependabot to create PRs for updates to Terraform providers.